### PR TITLE
:bug: Fixed getSessionAttribute(name) issue

### DIFF
--- a/lib/jovo.js
+++ b/lib/jovo.js
@@ -518,7 +518,7 @@ class Jovo extends EventEmitter {
      * @return {*}
      */
     getSessionAttribute(name) {
-        if (!this.getPlatform().getSessionAttribute(name)) {
+        if (this.getPlatform().getSessionAttribute(name) === undefined) {
             throw Error('Session attribute '+name+' not found');
         }
         return this.getPlatform().getSessionAttribute(name);


### PR DESCRIPTION
When attribute value is equal to zero, it triggers an error as if the attribute didn't exist