### PR TITLE
🐛 Fixed getState priority

### DIFF
--- a/lib/platforms/alexa/alexaSkill.js
+++ b/lib/platforms/alexa/alexaSkill.js
@@ -220,8 +220,8 @@ class AlexaSkill extends Platform {
      * @return {*}
      */
     getState() {
-        return this.request.getSessionAttribute('STATE') ||
-        this.response.getSessionAttribute('STATE');
+        return this.response.getSessionAttribute('STATE') ||
+        this.request.getSessionAttribute('STATE');
     }
 
     /** ***********************************************************


### PR DESCRIPTION
When using this method:
```
app.toStateIntent('anotherState', 'anotherIntent');
```
The new state is saved in the `response (AlexaResponse)` object, however, when calling the `app.getState()` method, it first looks for the old state in the request when I already changed it in the response to the new one.