### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@
 <a href="https://www.npmjs.com/package/jovo-framework" target="_blank"><img src="https://badge.fury.io/js/jovo-framework.svg"></a>
 <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
 <a href="https://slackin-uwinbxqkfx.now.sh" target="_blank"><img src="https://slackin-uwinbxqkfx.now.sh/badge.svg"></a>
- <a href="https://twitter.com/intent/tweet?text=🔈 Build cross-platform voice apps for Alexa and Google Assistant with @jovotech https://github.com/jovotech/jovo-framework-nodejs/" target="_blank"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
+<a href="https://www.codetriage.com/jovotech/jovo-framework-nodejs" target="_blank"><img src="https://www.codetriage.com/jovotech/jovo-framework-nodejs/badges/users.svg"></a>
+<a href="https://twitter.com/intent/tweet?text=🔈 Build cross-platform voice apps for Alexa and Google Assistant with @jovotech https://github.com/jovotech/jovo-framework-nodejs/" target="_blank"><img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"></a>
 </p>
 
 <br/>
 
 Jovo is the first open source framework that lets you build voice apps for both Amazon Alexa and Google Assistant with only one code base. Besides cross-platform development, Jovo also offers a variety of integrations and easy prototyping capabilities. [Check out our features below.](#features)
 
-> 🚀 Join our newsletter for free courses on voice app development: www.jovo.tech/newsletter 
+> 🚀 Join our newsletter for free courses on voice app development: www.jovo.tech/newsletter
 
 
 ## Table of Contents
@@ -93,7 +94,7 @@ Progressive Responses | Keep your users engaged while processing a longer reques
 Name | Description | Docs
 :--- | :--- | :---
 Google Assistant Cards &nbsp; &nbsp; &nbsp; | Create visual Output for the Google Assistant mobile app | [Example](https://github.com/jovotech/jovo-framework-nodejs/blob/master/examples/google_action_specific/indexGoogleAssistantCards.js)
-Suggestion Chips | Display buttons to allow your users to quickly reply on mobile phones | [📝](https://github.com/jovotech/jovo-framework-nodejs/tree/master/docs/04_platform-specifics/google-assistant/#suggestion-chips) 
+Suggestion Chips | Display buttons to allow your users to quickly reply on mobile phones | [📝](https://github.com/jovotech/jovo-framework-nodejs/tree/master/docs/04_platform-specifics/google-assistant/#suggestion-chips)
 
 ### Integrations
 


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.