### PR TITLE
Added Image Display Option feature for Google Action Basic Card

### DIFF
--- a/examples/google_action_specific/indexGoogleAssistantCards.js
+++ b/examples/google_action_specific/indexGoogleAssistantCards.js
@@ -51,7 +51,8 @@ let handlers = {
         let basicCard = new BasicCard()
             .setTitle('Title')
             .setImage('http://via.placeholder.com/450x350?text=Basic+Card', 'accessibilityText')
-            .setFormattedText('Formatted Text');
+            .setFormattedText('Formatted Text')
+            .setImageDisplay('WHITE');
 
         app.googleAction().showBasicCard(basicCard);
         app.googleAction().showSuggestionChips(['List', 'Carousel', 'Basic card']);

--- a/lib/platforms/googleaction/googleActionResponse.js
+++ b/lib/platforms/googleaction/googleActionResponse.js
@@ -992,6 +992,9 @@ class BasicCard {
             if (basicCard.image) {
                 this.image = basicCard.image;
             }
+            if (basicCard.imageDisplayOptions) {
+                this.imageDisplayOptions = basicCard.imageDisplayOptions;
+            }
             if (basicCard.buttons) {
                 this.buttons = basicCard.buttons;
             }
@@ -1091,6 +1094,22 @@ class BasicCard {
                 url: url,
             },
         });
+        return this;
+    }
+
+    /**
+     * Sets the image display option
+     * @param {string} image display option
+     * @return {BasicCard}
+     */
+    setImageDisplay(imageDisplayOptions) {
+        if (!imageDisplayOptions) {
+            throw new Error('Image Display Option cannot be empty');
+        }
+        if (['DEFAULT', 'WHITE', 'CROPPED'].indexOf(imageDisplayOptions) === -1) {
+            throw new Error('Image Display Option must be one of DEFAULT, WHITE, CROPPED');
+        }
+        this.imageDisplayOptions = imageDisplayOptions;
         return this;
     }
 


### PR DESCRIPTION
This option for the Basic Card is currently missing from the API. 

See: https://developers.google.com/actions/assistant/responses#basic_card