### PR TITLE
🐛 Fixed setSessionAttributes issue on Google Actions

### DIFF
--- a/lib/platforms/googleaction/googleAction.js
+++ b/lib/platforms/googleaction/googleAction.js
@@ -261,6 +261,16 @@ class GoogleAction extends Platform {
      * @param {*} value
      */
     setSessionAttributes(attributes) {
+        let sessionAttributes = this.getSessionAttributes();
+
+        if (_.keys(sessionAttributes).length === 0) {
+            this.response.addContextOutObject({
+                name: 'session',
+                lifespan: 10000,
+                parameters: {},
+            });
+        }
+
         _.map(attributes, (value, name) => {
             this.response.addContextOutParameter('session', name, value);
         });
@@ -275,7 +285,7 @@ class GoogleAction extends Platform {
     setSessionAttribute(name, value) {
         let sessionAttributes = this.getSessionAttributes();
 
-        if (Object.keys(sessionAttributes).length === 0) {
+        if (_.keys(sessionAttributes).length === 0) {
             this.response.addContextOutObject({
                 name: 'session',
                 lifespan: 10000,

--- a/lib/platforms/googleaction/googleAction.js
+++ b/lib/platforms/googleaction/googleAction.js
@@ -271,9 +271,7 @@ class GoogleAction extends Platform {
             });
         }
 
-        _.map(attributes, (value, name) => {
-            this.response.addContextOutParameter('session', name, value);
-        });
+        this.response.setContextOutParameters('session', attributes);
     }
 
     /**

--- a/lib/platforms/googleaction/googleActionResponse.js
+++ b/lib/platforms/googleaction/googleActionResponse.js
@@ -86,6 +86,18 @@ class GoogleActionResponse {
     }
 
     /**
+     * Sets parameters to context
+     * @param {string} contextName
+     * @param {{}} parameters
+     * @return {GoogleActionResponse}
+     */
+    setContextOutParameters(contextName, parameters) {
+        let context = this.getContextOut(contextName);
+        context.parameters = parameters;
+        return this;
+    }
+
+    /**
      * Adds parameter to a given context object
      * @param {string} contextName
      * @param {string} parameterName

--- a/lib/platforms/googleaction/googleActionResponse.js
+++ b/lib/platforms/googleaction/googleActionResponse.js
@@ -107,7 +107,7 @@ class GoogleActionResponse {
     getContextOutParameter(contextName, parameterName) {
         let context = this.getContextOut(contextName);
         if (!context) {
-            throw new Error('No context with name '+contextName+' found.');
+            throw new Error(`No context with name ${contextName} found.`);
         }
         return context.parameters[parameterName];
     }
@@ -208,7 +208,7 @@ class GoogleActionResponse {
      * @return {GoogleActionResponse}
      */
     play(audioUrl, fallbackText) {
-        let speech = '<speak><audio src="'+audioUrl+'">' + fallbackText + '</audio></speak>';
+        let speech = `<speak><audio src="${audioUrl}">${fallbackText}</audio></speak>`;
         return this.tell(speech);
     }
 
@@ -350,7 +350,7 @@ class GoogleActionResponse {
             .items.unshift(
             {
                 simpleResponse: {
-                    ssml: '<speak>' + displayText + '</speak>',
+                    ssml: `<speak>${displayText}</speak>`,
                     displayText: displayText,
                 },
             }
@@ -530,7 +530,7 @@ class GoogleActionResponse {
      * @return {boolean}
      */
     isPlay(audioUrl, fallbackText) {
-        let speech = '<speak><audio src="'+audioUrl+'">' + fallbackText + '</audio></speak>';
+        let speech = `<speak><audio src="${audioUrl}">${fallbackText}</audio></speak>`;
         return this.isTell(speech);
     }
 


### PR DESCRIPTION
When I want to drop several attributes using `app.setSessionAttributes(myAttributes);` in my `NEW_SESSION` or `LAUNCH` functions, I'm simply not able to, since the `session` context is not initialized.