### PR TITLE
Added aliases for Speechbuilder's 'say-as' methods

### DIFF
--- a/lib/platforms/speechBuilder.js
+++ b/lib/platforms/speechBuilder.js
@@ -49,11 +49,33 @@ class SpeechBuilder {
      * @param {float} probability
      * @return {SpeechBuilder}
      */
+    addCardinal(number, condition, probability) {
+        return this.addSayAsCardinal(number, condition, probability);
+    }
+
+    /**
+     * Adds <say-as> tags with interpret-as ordinal
+     * @param {string} number
+     * @param {boolean} condition
+     * @param {float} probability
+     * @return {SpeechBuilder}
+     */
     addSayAsOrdinal(number, condition, probability) {
         if (_.isArray(number)) {
             number = _.sample(number);
         }
         return this.addText('<say-as interpret-as="ordinal">'+number+'</say-as>', condition, probability);
+    }
+
+    /**
+     * Adds <say-as> tags with interpret-as ordinal
+     * @param {string} number
+     * @param {boolean} condition
+     * @param {float} probability
+     * @return {SpeechBuilder}
+     */
+    addOrdinal(number, condition, probability) {
+        return this.addSayAsOrdinal(number, condition, probability);
     }
 
     /**
@@ -68,6 +90,17 @@ class SpeechBuilder {
             characters = _.sample(characters);
         }
         return this.addText('<say-as interpret-as="characters">'+characters+'</say-as>', condition, probability);
+    }
+
+    /**
+     * Adds <say-as> tags with interpret-as characters
+     * @param {string} characters
+     * @param {boolean} condition
+     * @param {float} probability
+     * @return {SpeechBuilder}
+     */
+    addCharacters(characters, condition, probability) {
+        return this.addSayAsCharacters(characters, condition, probability);
     }
 
     /**


### PR DESCRIPTION
I've added three methods to the `speechBuilder` class:
- `addCardinal`
- `addOrdinal`
- `addCharacters`
These methods do nothing but to call the existing methods `addSayAsCardinal`, `addSayAsOrdinal` and `addSayAsCharacters`, respectively, and to pass their arguments (`number` or `characters`, `condition` and `probability`). In this sense, they provide an alias for the three existing functions.

This pull request is motivated by the fact that I use those functions occasionally, but couldn't remember their names and had to look them up every time I used them.