### PR TITLE
Fix dialogflow V2 input handling (issue #116)

### DIFF
--- a/lib/platforms/googleaction/googleAction.js
+++ b/lib/platforms/googleaction/googleAction.js
@@ -453,16 +453,18 @@ class GoogleAction extends Platform {
 
         if (this.request.constructor.name === 'DialogFlowV2Request' ||
             this.request.constructor.name === 'GoogleActionDialogFlowV2Request') {
-            for (let context of res.contextOut) {
-                if (context.name === 'session') {
-                    context.name = this.request.getSession() + '/contexts/session';
-                    context.lifespanCount = context.lifespan;
-                    delete context.lifespan;
+            if (res.contextOut) {
+                for (let context of res.contextOut) {
+                    if (context.name === 'session') {
+                        context.name = this.request.getSession() + '/contexts/session';
+                        context.lifespanCount = context.lifespan;
+                        delete context.lifespan;
+                    }
                 }
+                // res.contextOut = res.contextOut.splice(res.contextOut.length-1,1);
+                // delete res.contextOut[res.contextOut.length-1];
+                // res.contextOut.pop();
             }
-            // res.contextOut = res.contextOut.splice(res.contextOut.length-1,1);
-            // delete res.contextOut[res.contextOut.length-1];
-            // res.contextOut.pop();
             return {
                 fulfillmentText: res.speech,
                 payload: res.data,

--- a/lib/platforms/googleaction/request/dialogFlowV2Request.js
+++ b/lib/platforms/googleaction/request/dialogFlowV2Request.js
@@ -36,9 +36,12 @@ class DialogFlowV2Request extends NLUBase {
      * @return {*}
      */
     getInputs() {
-        return _.get(this, 'queryResult.parameters');
+        const params = _.get(this, 'queryResult.parameters');
+        return _.mapValues(params, (value, name) => ({
+            name,
+            value,
+        }));
     }
-
 
     /**
      * Returns response id

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
-    "dashbot": "^9.5.0",
     "eslint": "^3.19.0",
     "eslint-config-google": "^0.8.0",
     "mocha": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
+    "dashbot": "^9.5.0",
     "eslint": "^3.19.0",
     "eslint-config-google": "^0.8.0",
     "mocha": "^3.5.0"


### PR DESCRIPTION
This PR fixes #116 where inputs are passed as plain strings rather than objects. It also handles the case where `res.contextOut` is `undefined` which happens when V2 requests are issued by the dialogflow web interface.

**Notes:**

In V1 the input objects also have a `key` and `id` property that both contain the value. I have no idea what they are for.

I had to add `dashbot` as devDependency in order to get all tests passing.

I tried to add a test, but failed to find a good starting point.


