### PR TITLE
 🐛 fixes getTimestamp() on googleAction requests v1 & v2

### DIFF
--- a/lib/platforms/googleaction/request/dialogFlowV2Request.js
+++ b/lib/platforms/googleaction/request/dialogFlowV2Request.js
@@ -67,7 +67,7 @@ class DialogFlowV2Request extends NLUBase {
      * @return {*}
      */
     getTimestamp() {
-        return _.get(this, new Date().toISOString());
+        return new Date().toISOString();
     }
 
     /**

--- a/lib/platforms/googleaction/request/googleActionDialogFlowRequest.js
+++ b/lib/platforms/googleaction/request/googleActionDialogFlowRequest.js
@@ -76,7 +76,7 @@ class GoogleActionDialogFlowRequest extends DialogFlowRequest {
      * @return {string}
      */
     getTimestamp() {
-        return this.getTimestamp();
+        return super.getTimestamp();
     }
 
     /**

--- a/lib/platforms/googleaction/request/googleActionDialogFlowV2Request.js
+++ b/lib/platforms/googleaction/request/googleActionDialogFlowV2Request.js
@@ -78,7 +78,7 @@ class GoogleActionDialogFlowV2Request extends DialogFlowV2Request {
      * @return {string}
      */
     getTimestamp() {
-        return this.getTimestamp();
+        return super.getTimestamp();
     }
 
     /**


### PR DESCRIPTION
`this.getTimestamp()` causes infinite loop