### PR TITLE
Register plugins without a name

### DIFF
--- a/docs/07_advanced/README.md
+++ b/docs/07_advanced/README.md
@@ -181,10 +181,10 @@ class PluginName extends Plugin {
 In the app, the plugin can then get registered. The `constructor` part of the plugin can be used to define certain `options` that the plugin needs to work (e.g. credentials):
 
 ```javascript
-app.register('PluginName', new PluginName());
+app.register(new PluginName());
 
 // If you define options in your constructor
-app.register('PluginName', new PluginName(options));
+app.register(new PluginName(options));
 ```
 
 In `init()`, you can define listeners and what to do when a certain event happens. The example below logs the `Request Type` for any incoming request: 

--- a/lib/app.js
+++ b/lib/app.js
@@ -1000,7 +1000,7 @@ class BaseApp extends EventEmitter {
      * @param {*} listener
      */
     register(name, listener) {
-        if (typeof name == 'object') {
+        if (typeof name === 'object') {
             listener = name;
             name = listener.constructor.name;
         }

--- a/lib/app.js
+++ b/lib/app.js
@@ -1000,6 +1000,10 @@ class BaseApp extends EventEmitter {
      * @param {*} listener
      */
     register(name, listener) {
+        if (typeof name == 'object') {
+            listener = name;
+            name = listener.constructor.name;
+        }
         if (!this.config.plugins) {
             this.config.plugins = {};
         }

--- a/test/integrations/plugin.js
+++ b/test/integrations/plugin.js
@@ -1,3 +1,4 @@
+'use strict';
 const App = require('../../lib/app').App;
 const Plugin = require('../../lib/integrations/plugin').Plugin;
 const expect = require('chai').expect;

--- a/test/integrations/plugin.js
+++ b/test/integrations/plugin.js
@@ -1,0 +1,47 @@
+const {App} = require('../../lib/app');
+const {Plugin} = require('../../lib/integrations/plugin');
+const expect = require('chai').expect;
+
+describe('plugin', () => {
+  describe('register with name', () => {
+    it('should be initialized', (done) => {
+      const app = new App();
+      app.register('plugin', new TestPlugin({
+        onInit() {
+          expect(this.app).to.equal(app);
+          done();
+        },
+      }));
+    });
+  });
+
+  describe('register without name', () => {
+    it('should be initialized', (done) => {
+      const app = new App();
+      app.register(new TestPlugin({
+        onInit() {
+          expect(this.app).to.equal(app);
+          done();
+        },
+      }));
+    });
+    it('should have a name', () => {
+      const app = new App();
+      const plugin = new Plugin();
+      app.register(plugin);
+      expect(app.config.plugins).to.have.property('Plugin', plugin);
+    });
+  });
+});
+
+/**
+ * Dummy Plugin for testing.
+ */
+class TestPlugin extends Plugin {
+  /**
+   * Invokes the onInit callback passed as option.
+   */
+  init() {
+    this.options.onInit.call(this);
+  }
+}

--- a/test/integrations/plugin.js
+++ b/test/integrations/plugin.js
@@ -1,5 +1,5 @@
-const {App} = require('../../lib/app');
-const {Plugin} = require('../../lib/integrations/plugin');
+const App = require('../../lib/app').App;
+const Plugin = require('../../lib/integrations/plugin').Plugin;
 const expect = require('chai').expect;
 
 describe('plugin', () => {


### PR DESCRIPTION
## Proposed changes

This PR removes the need to specify a name when registering plugins and uses the class name as default. The old way is still supported, though. I have updated the docs to only show the new way since it is simpler and less confusing ("why should I specify a name?").

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed