### PR TITLE
Prevent (and gracefully handle) DynamoDB errors

### DIFF
--- a/lib/integrations/db/dynamoDb.js
+++ b/lib/integrations/db/dynamoDb.js
@@ -28,7 +28,9 @@ class DynamoDb {
         }
         this.tableName = tableName;
         this.dynamoClient = new this.aws.DynamoDB();
-        this.docClient = new this.aws.DynamoDB.DocumentClient();
+        this.docClient = new this.aws.DynamoDB.DocumentClient({
+            convertEmptyValues: true,
+        });
     }
     /**
      * Sets mainkey (userId)

--- a/lib/jovo.js
+++ b/lib/jovo.js
@@ -914,11 +914,8 @@ class Jovo extends Platform {
                     .saveObject(
                         this.config.dynamoDbKey,
                         this.getSessionAttributes(), (err, data) => {
-                            if (err) {
-                                reject(err);
-                            }
-
-                            resolve(data);
+                            if (err) reject(err);
+                            else resolve(data);
                         });
             } else {
                 resolve();

--- a/lib/jovo.js
+++ b/lib/jovo.js
@@ -891,12 +891,10 @@ class Jovo extends Platform {
      * @return {Promise}
      */
     saveUserDataOnResponse() {
-        return new Promise((resolve, reject) => {
-            if (!this.config.saveUserOnResponseEnabled) {
-                return resolve();
-            }
-            return this.user().saveDataToDb().then(resolve);
-        });
+        if (!this.config.saveUserOnResponseEnabled) {
+            return Promise.resolve();
+        }
+        return this.user().saveDataToDb();
     }
 
 

--- a/lib/jovo.js
+++ b/lib/jovo.js
@@ -48,6 +48,7 @@ class Jovo extends Platform {
                 .then(this.executeResponse())
                 .catch((err) => {
                     console.log('Error on respond', err);
+                    this.app.emit('responseError', this, err);
                 });
         });
     }


### PR DESCRIPTION
## Proposed changes

DynamoDB does not support empty Strings. If the session contains empty (or `null`) values one gets the following error upon save:

> ValidationException: One or more parameter values were invalid: An AttributeValue may not contain an empty string

The error is not properly handled and yields an unhandled promise rejection error.

This PR addresses both issues and emits a new app-event called `responseError` to allow plugins to report/log the error. 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed