### PR TITLE
Fix typo in JS example for repeat() function

### DIFF
--- a/docs/04_app-logic/03_output/README.md
+++ b/docs/04_app-logic/03_output/README.md
@@ -73,7 +73,7 @@ It is recommended to use a `'RepeatIntent'` (e.g. the `'AMAZON.RepeatIntent'`) t
 this.repeat();
 
 // Example
-'RepeatIntent' function() {
+'RepeatIntent': function() {
     this.repeat();
 }
 ```


### PR DESCRIPTION
## Proposed changes
Fixed a typo in the JS example for the repeat() function on the /docs/output page.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed