### PR TITLE
Adding support for audio track metadata in the Alexa Audio Player.

### DIFF
--- a/docs/05_platform-specifics/amazon-alexa/audioplayer.md
+++ b/docs/05_platform-specifics/amazon-alexa/audioplayer.md
@@ -44,6 +44,15 @@ this.alexaSkill().audioPlayer().enqueue(url, token)
 this.alexaSkill().audioPlayer().stop();
 ```
 
+### Set Track Metadata
+```javascript
+this.alexaSkill().audioPlayer()
+    .setTitle("First Track")
+    .setSubtitle("A simple subtitle")
+    .addArtwork("https://www.somewhere.com/image.png")
+    .addBackgroundImage("https://www.somewhere.com/background.jpg")
+```
+
 
 ## AudioPlayer Directives
 

--- a/lib/platforms/alexaSkill/audioPlayer.js
+++ b/lib/platforms/alexaSkill/audioPlayer.js
@@ -139,7 +139,7 @@ class AudioPlayer {
             audioItem.stream.expectedPreviousToken = this.expectedPreviousToken;
         }
 
-        if(this.metadata) {
+        if (this.metadata) {
             audioItem.metadata = this.metadata;
         }
 
@@ -148,11 +148,12 @@ class AudioPlayer {
 
     /**
      * Adds a track title to be displayed
-     * @param {string} title 
+     * @param {string} title
+     * @return {AudioPlayer}
      */
     setTitle(title) {
-        if(!this.metadata) {
-            this.metadata = {}
+        if (!this.metadata) {
+            this.metadata = {};
         }
 
         this.metadata.title = title;
@@ -161,11 +162,12 @@ class AudioPlayer {
 
     /**
      * Adds a track subtitle to be displayed
-     * @param {string} title 
+     * @param {string} subtitle
+     * @return {AudioPlayer}
      */
     setSubtitle(subtitle) {
-        if(!this.metadata) {
-            this.metadata = {}
+        if (!this.metadata) {
+            this.metadata = {};
         }
 
         this.metadata.subtitle = subtitle;
@@ -174,15 +176,16 @@ class AudioPlayer {
 
     /**
      * Adds a track image
-     * @param {string} title 
+     * @param {string} url
+     * @return {AudioPlayer}
      */
     addArtwork(url) {
-        if(!this.metadata) {
-            this.metadata = {}
+        if (!this.metadata) {
+            this.metadata = {};
         }
 
-        if(!this.metadata.art) {
-            this.metadata.art = { sources: [] }
+        if (!this.metadata.art) {
+            this.metadata.art = {sources: []};
         }
 
         this.metadata.art.sources.push({url});
@@ -191,15 +194,16 @@ class AudioPlayer {
 
     /**
      * Adds an image to be displayed behind the track information
-     * @param {string} title 
+     * @param {string} url
+     * @return {AudioPlayer}
      */
     addBackgroundImage(url) {
-        if(!this.metadata) {
-            this.metadata = {}
+        if (!this.metadata) {
+            this.metadata = {};
         }
 
-        if(!this.metadata.backgroundImage) {
-            this.metadata.backgroundImage = { sources: [] }
+        if (!this.metadata.backgroundImage) {
+            this.metadata.backgroundImage = {sources: []};
         }
 
         this.metadata.backgroundImage.sources.push({url});

--- a/lib/platforms/alexaSkill/audioPlayer.js
+++ b/lib/platforms/alexaSkill/audioPlayer.js
@@ -127,7 +127,7 @@ class AudioPlayer {
      * @return {*}
      */
     createAudioItem(url, token) {
-        let stream = {
+        let audioItem = {
             stream: {
                 token: token,
                 url: url,
@@ -136,10 +136,74 @@ class AudioPlayer {
         };
 
         if (this.expectedPreviousToken) {
-            stream.stream.expectedPreviousToken = this.expectedPreviousToken;
+            audioItem.stream.expectedPreviousToken = this.expectedPreviousToken;
         }
 
-        return stream;
+        if(this.metadata) {
+            audioItem.metadata = this.metadata;
+        }
+
+        return audioItem;
+    }
+
+    /**
+     * Adds a track title to be displayed
+     * @param {string} title 
+     */
+    setTitle(title) {
+        if(!this.metadata) {
+            this.metadata = {}
+        }
+
+        this.metadata.title = title;
+        return this;
+    }
+
+    /**
+     * Adds a track subtitle to be displayed
+     * @param {string} title 
+     */
+    setSubtitle(subtitle) {
+        if(!this.metadata) {
+            this.metadata = {}
+        }
+
+        this.metadata.subtitle = subtitle;
+        return this;
+    }
+
+    /**
+     * Adds a track image
+     * @param {string} title 
+     */
+    addArtwork(url) {
+        if(!this.metadata) {
+            this.metadata = {}
+        }
+
+        if(!this.metadata.art) {
+            this.metadata.art = { sources: [] }
+        }
+
+        this.metadata.art.sources.push({url});
+        return this;
+    }
+
+    /**
+     * Adds an image to be displayed behind the track information
+     * @param {string} title 
+     */
+    addBackgroundImage(url) {
+        if(!this.metadata) {
+            this.metadata = {}
+        }
+
+        if(!this.metadata.backgroundImage) {
+            this.metadata.backgroundImage = { sources: [] }
+        }
+
+        this.metadata.backgroundImage.sources.push({url});
+        return this;
     }
 
 


### PR DESCRIPTION
## Proposed changes
This PR adds support for setting the Title, Subtitle, Artwork, and Background image for an audio track for Alexa's audio player.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed