### PR TITLE
🐛 Fixed canFulfillRequest response format

### DIFF
--- a/lib/jovo.js
+++ b/lib/jovo.js
@@ -767,31 +767,28 @@ class Jovo extends Platform {
     /**
      * Sets positive can fulfill request values.
      * @public
-     * @return {Jovo} this
      */
     canFulfillRequest() {
         this.getPlatform().canFulfillRequest('YES');
-        return this;
+        this.respond();
     }
 
     /**
      * Sets negative can fulfill request values.
      * @public
-     * @return {Jovo} this
      */
     cannotFulfillRequest() {
         this.getPlatform().canFulfillRequest('NO');
-        return this;
+        this.respond();
     }
 
     /**
      * Sets possible can fulfill request values.
      * @public
-     * @return {Jovo} this
      */
     mayFulfillRequest() {
         this.getPlatform().canFulfillRequest('MAYBE');
-        return this;
+        this.respond();
     }
 
     /**

--- a/lib/platforms/alexaSkill/alexaResponse.js
+++ b/lib/platforms/alexaSkill/alexaResponse.js
@@ -91,9 +91,12 @@ class AlexaResponse {
      * @param {string} canFulfill
      */
     setCanFulfillIntent(canFulfill) {
-        this.responseObj.response.canFulfillIntent = {
-            canFulfill,
-        };
+        const canFulfillIntent = this.responseObj.response.canFulfillIntent || {};
+        canFulfillIntent.canFulfill = canFulfill;
+
+        this.responseObj.response.canFulfillIntent = canFulfillIntent;
+        this.responseObj.response.shouldEndSession = undefined;
+        this.responseObj.sessionAttributes = undefined;
     }
 
     /**


### PR DESCRIPTION
## Proposed changes
According to the high-level overview:
https://developer.amazon.com/docs/custom-skills/understand-name-free-interaction-for-custom-skills.html#high-level-overview-of-how-name-free-interaction-works

The response to the `CanFulfillIntentRequest` should finish the interaction. In my previous PR, I left a whole so user continue adding operations. But the framework should finish the flow and respond after developer decides to fulfill the request or not.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed