### PR TITLE
Fixed broken link on installation page.

### DIFF
--- a/docs/01_getting-started/README.md
+++ b/docs/01_getting-started/README.md
@@ -91,7 +91,7 @@ You can find out more about the Jovo project structure in [App Configuration](..
 
 Before building out the logic of your voice application, you need to create a language model (also called interaction model) on the voice platform(s) you want to interact with.
 
-If you're new to how the voice platforms and language models work, take a look at [Voice App Basics](voice-app-basics.md './voice-app-basics').
+If you're new to how the voice platforms and language models work, take a look at [Voice App Basics](./voice-app-basics.md './voice-app-basics').
 
 There are several ways how to do that:
 * Create the language models manually for each platform in the respective developer console


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes in detail -->
<!--- If the PR addresses an issue, please link to it here -->
The link for "Voice App Basics" on the Installation page [under step 3](https://www.jovo.tech/docs/installation#3-create-a-language-model) went to a 404 when I clicked on it. I made it not do that by adding a missing `./`. I look forward to using Jovo in upcoming projects!

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed