### PR TITLE
🔨 Added validation method for ISP and en-US locale

### DIFF
--- a/lib/platforms/alexaSkill/inSkillPurchase.js
+++ b/lib/platforms/alexaSkill/inSkillPurchase.js
@@ -17,6 +17,21 @@ class InSkillPurchase {
     }
 
     /**
+     * Verifies if user's account is valid for en-US ISP feature
+     * @return {boolean}
+     */
+    isIspAllowed() {
+        const ALLOWED_ISP_ENDPOINTS = {
+            'en-US': 'https://api.amazonalexa.com',
+        };
+
+        const locale = this.jovo.getLocale();
+        const endpoint = this.jovo.getPlatform().getApiEndpoint();
+
+        return ALLOWED_ISP_ENDPOINTS[locale] === endpoint;
+    }
+
+    /**
      * Sends buy request
      * @param {string} productId your product id in the format amzn1.adg.product
      * @param {string} token


### PR DESCRIPTION
## Proposed changes
According to the docs, for now it is allowed to do ISP only in the US market:
https://developer.amazon.com/docs/in-skill-purchase/isp-faqs.html

When trying to sell products for non-US locales Alexa sends an error but you still get a response from Alexa. In my case, I was working with an Australian guy who has an `en-US` skill. When he tried to test it out, his AMZ account was associated with the Australian market, and even though he switched to work with the `en-US` locale in the simulator, the Alexa service still recognized the Australian origin and sent the far east endpoint.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed