### PR TITLE
Fix: handle requests without session attributes

### DIFF
--- a/lib/platforms/alexaSkill/alexaSkill.js
+++ b/lib/platforms/alexaSkill/alexaSkill.js
@@ -47,7 +47,7 @@ class AlexaSkill extends Platform {
         if (!this.nlu) {
             this.nlu = new AlexaNLU(this.request);
         }
-        if (_.get(this, 'request.session') && this.request.getSessionAttributes()) {
+        if (this.hasSessionAttributes()) {
             this.jovo.setSessionAttributes(_.cloneDeep(this.request.getSessionAttributes()));
         }
     }

--- a/lib/platforms/alexaSkill/alexaSkill.js
+++ b/lib/platforms/alexaSkill/alexaSkill.js
@@ -175,7 +175,7 @@ class AlexaSkill extends Platform {
      * @return {boolean}
      */
     hasSessionAttributes() {
-        return_.get(this, 'request.session') && this.request.getSessionAttributes && this.request.getSessionAttributes();
+        return _.get(this, 'request.session') && this.request.getSessionAttributes && this.request.getSessionAttributes();
     }
 
     /**

--- a/lib/platforms/alexaSkill/alexaSkill.js
+++ b/lib/platforms/alexaSkill/alexaSkill.js
@@ -170,6 +170,15 @@ class AlexaSkill extends Platform {
     }
 
     /**
+     * Return true if session attributes are available
+     * @public
+     * @return {boolean}
+     */
+    hasSessionAttributes() {
+        return_.get(this, 'request.session') && this.request.getSessionAttributes && this.request.getSessionAttributes();
+    }
+
+    /**
      * Returns video capibility of device
      * @public
      * @return {boolean}


### PR DESCRIPTION
## Proposed changes
When an error is returned from Alexa, an exception is thrown because the `getSessionAttributes` method isn't a member of `ErrorRequest`. This PR adds a check for the existence of `getSessionAttributes`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed