### PR TITLE
Fix SequenceBuilder being added multiple times

### DIFF
--- a/lib/platforms/alexaSkill/gadgetController.js
+++ b/lib/platforms/alexaSkill/gadgetController.js
@@ -178,9 +178,9 @@ class AnimationsBuilder {
         _.map(sequence, (item) => {
             if (item instanceof SequenceBuilder) {
                 this.animation.sequence.push(item.build());
+            } else {
+                this.animation.sequence.push(item);
             }
-
-            this.animation.sequence.push(item);
         });
 
         return this;


### PR DESCRIPTION
## Proposed changes
Currently, if I add a `SequenceBuilder` to an `AnimationBuilder` it will first `build()` will be called and the result will be added to the `AnimationBuilder`, then the original `SequenceBuilder` object is added.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed