### PR TITLE
Reminders Fix

### DIFF
--- a/lib/platforms/alexaSkill/alexaUser.js
+++ b/lib/platforms/alexaSkill/alexaUser.js
@@ -31,6 +31,7 @@ class AlexaUser extends User {
 
         this.alexaReminder = new AlexaReminder(
             this.getPermissionToken(),
+            this.getApiAccessToken(),
             this.getApiEndpoint());
     }
 
@@ -655,10 +656,12 @@ class AlexaReminder {
     /**
      * Constructor
      * @param {string} permissionToken
+     * @param {string} accessToken
      * @param {string} apiEndpoint
      */
-    constructor(permissionToken, apiEndpoint) {
+    constructor(permissionToken, apiAccessToken, apiEndpoint) {
         this.permissionToken = permissionToken;
+        this.apiAccessToken = apiAccessToken;
         this.apiEndpoint = apiEndpoint;
     }
 
@@ -678,7 +681,7 @@ class AlexaReminder {
             let options = {
                 endpoint: this.apiEndpoint,
                 path: '/v1/alerts/reminders',
-                permissionToken: this.permissionToken,
+                permissionToken: this.apiAccessToken,
                 json: reminder,
                 method: 'POST',
             };
@@ -704,7 +707,7 @@ class AlexaReminder {
             let options = {
                 endpoint: this.apiEndpoint,
                 path: `/v1/alerts/reminders/${alertToken}`,
-                permissionToken: this.permissionToken,
+                permissionToken: this.apiAccessToken,
                 json: reminder,
                 method: 'PUT',
             };
@@ -730,7 +733,7 @@ class AlexaReminder {
             let options = {
                 endpoint: this.apiEndpoint,
                 path: `/v1/alerts/reminders/${alertToken}`,
-                permissionToken: this.permissionToken,
+                permissionToken: this.apiAccessToken,
                 method: 'DELETE',
             };
 
@@ -753,7 +756,7 @@ class AlexaReminder {
             let options = {
                 endpoint: this.apiEndpoint,
                 path: '/v1/alerts/reminders',
-                permissionToken: this.permissionToken,
+                permissionToken: this.apiAccessToken,
                 method: 'GET',
             };
 
@@ -777,7 +780,7 @@ class AlexaReminder {
             let options = {
                 endpoint: this.apiEndpoint,
                 path: `/v1/alerts/reminders/${alertToken}`,
-                permissionToken: this.permissionToken,
+                permissionToken: this.apiAccessToken,
                 method: 'GET',
             };
 

--- a/lib/platforms/alexaSkill/alexaUser.js
+++ b/lib/platforms/alexaSkill/alexaUser.js
@@ -656,7 +656,7 @@ class AlexaReminder {
     /**
      * Constructor
      * @param {string} permissionToken
-     * @param {string} accessToken
+     * @param {string} apiAccessToken
      * @param {string} apiEndpoint
      */
     constructor(permissionToken, apiAccessToken, apiEndpoint) {


### PR DESCRIPTION
## Proposed changes
Fixes issue with reminders API token. It seems for the new reminders endpoint the apiAccessToken should be used as the Bearer rather than the consentToken.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed