### PR TITLE
Fix broken link to newsletter sign-up form

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [Take a look at the docs on our website, they're prettier there!](https://www.jovo.tech/framework/docs/)
 
-> 🚀 Join our newsletter for free courses on voice app development: [www.jovo.tech/newsletter](www.jovo.tech/newsletter) 
+> 🚀 Join our newsletter for free courses on voice app development: [www.jovo.tech/newsletter](https://www.jovo.tech/newsletter) 
 
 ## Content
 


### PR DESCRIPTION
## Proposed changes

The missing `https://` rendered a link to https://github.com/jovotech/jovo-framework-nodejs/blob/v2/docs/www.jovo.tech/newsletter

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed